### PR TITLE
Fix subtype filtering in getEvents

### DIFF
--- a/src/MIDIFile.js
+++ b/src/MIDIFile.js
@@ -86,7 +86,7 @@ MIDIFile.prototype.getEvents = function(type, subtype) {
         }
         // push the asked events
         if(((!type) || event.type === type) &&
-          ((!subtype) || (event.subtype && event.subtype === type))) {
+          ((!subtype) || (event.subtype && event.subtype === subtype))) {
           event.playTime = playTime;
           filteredEvents.push(event);
         }
@@ -135,7 +135,7 @@ MIDIFile.prototype.getEvents = function(type, subtype) {
         }
         // push midi events
         if(((!type) || event.type === type) &&
-          ((!subtype) || (event.subtype && event.subtype === type))) {
+          ((!subtype) || (event.subtype && event.subtype === subtype))) {
           event.playTime = playTime;
           event.track = smallestDelta;
           filteredEvents.push(event);


### PR DESCRIPTION
The getEvents function accepts an optional subtype filter however this parameter was not being used. Rather, if subtype was set then it was matching event.subtype against the _type_ parameter instead.