### PR TITLE
Accept UInt8Arrays and thus, Node.js Buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can also find a very [trivial MIDI player](http://rawgit.com/nfroidure/MIDIF
 
 ## Usage
 ```js
-// Your variable with a ArrayBuffer instance containing your MIDI file
+// Your variable with your MIDI file as an ArrayBuffer or UInt8Array instance
 var anyBuffer;
 
 // Creating the MIDIFile instance

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Read/write standard MIDI files.",
   "main": "src/MIDIFile",
   "author": "Nicolas Froidure",
+  "contributors": [
+    "M.K. (https://github.com/mk-pmb)"
+  ],
   "metapak": {
     "data": {
       "files": "src/*.js tests/*.mocha.js",

--- a/src/MIDIFile.js
+++ b/src/MIDIFile.js
@@ -8,6 +8,20 @@ var MIDIFileTrack = require('./MIDIFileTrack');
 var MIDIEvents = require('midievents');
 var UTF8 = require('utf-8');
 
+
+function ensureArrayBuffer(buf) {
+  if (buf) {
+    if (buf instanceof ArrayBuffer) { return buf; }
+    if (buf instanceof Uint8Array) {
+      // Copy/convert to standard Uint8Array, because derived classes like
+      // node.js Buffers might have unexpected data in the .buffer property.
+      return new Uint8Array(buf).buffer;
+    }
+  }
+  throw new Error('Unsupported buffer type, need ArrayBuffer or Uint8Array');
+}
+
+
 // Constructor
 function MIDIFile(buffer, strictMode) {
   var track;
@@ -22,9 +36,7 @@ function MIDIFile(buffer, strictMode) {
     this.tracks = [new MIDIFileTrack()];
   // if a buffer is provided, parsing him
   } else {
-    if(!(buffer instanceof ArrayBuffer)) {
-      throw new Error('Invalid buffer received.');
-    }
+    buffer = ensureArrayBuffer(buffer);
     // Minimum MIDI file size is a headerChunk size (14bytes)
     // and an empty track (8+3bytes)
     if(25 > buffer.byteLength) {

--- a/tests/midifile.mocha.js
+++ b/tests/midifile.mocha.js
@@ -269,6 +269,11 @@ describe('Reading well formed MIDI files', function() {
     assert.equal(events.byteLength, 47411);
     assert.equal(events.byteOffset, 22);
   });
+
+  it('MIDI data from a Node.js buffer', function() {
+    var data = 'TVRoZAAAAAYAAQABAeBNVHJrAAAAFAD/BAAAwAAAkEVVkmCARVUA/y8A';
+    new MIDIFile(Buffer.from(data, 'base64'));
+  });
 });
 
 


### PR DESCRIPTION
Took me quite a while to understand that I had been mislead by the
readme's variable name, `anyBuffer` – I thought the module just
wouldn't support the flavor of MIDI file format.
Now at least standard buffers (as from `fs.readFile`) do work.

I had to skip linting because `npm run lint` seems to not work on my machine: It found a whole screen full of problems even in original master (c322a1aa7c47a42f491798d1a27a4b8e85a642a5).

### Code quality
[x] I made some tests for my changes

[x] I'm a nice person

My NPM username: mk-pmb